### PR TITLE
Add Redis.Cluster for commands

### DIFF
--- a/src/initCommands.ts
+++ b/src/initCommands.ts
@@ -9,7 +9,7 @@ import {defineGetKeyRangeCommand} from './operations/getKeyRange';
 import {defineRemoveKeyRangeCommand} from './operations/removeKeyRange';
 import {defineRemoveVersionRangeCommand} from './operations/removeVersionRange';
 
-export function initCommands(redis: IORedis.Redis): void {
+export function initCommands(redis: IORedis.Cluster | IORedis.Redis): void {
   defineGetCommand(redis);
   defineSetCommand(redis);
   defineCompareAndSetCommand(redis);

--- a/src/operations/compareAndRemove.ts
+++ b/src/operations/compareAndRemove.ts
@@ -102,7 +102,7 @@ export function transformCompareAndRemoveReply(
 }
 
 export function compareAndRemove(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   key: string | Buffer,
   compareOperator: CompareOperator,

--- a/src/operations/compareAndRemove.ts
+++ b/src/operations/compareAndRemove.ts
@@ -31,6 +31,20 @@ declare module 'ioredis' {
     ): Promise<[Buffer, null | 1]>;
   }
 
+  interface Cluster {
+    lcCompareAndRemoveBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      key: string | Buffer,
+      compareOperator: string,
+      compareVersion: string,
+      maxlen: number,
+    ): Promise<[Buffer, null | 1]>;
+  }
+
   interface Pipeline {
     lcCompareAndRemoveBuffer(
       valuesKey: string,
@@ -47,7 +61,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineCompareAndRemoveCommand(redis: IORedis.Redis) {
+export function defineCompareAndRemoveCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcCompareAndRemove', definition);
 }
 

--- a/src/operations/compareAndSet.ts
+++ b/src/operations/compareAndSet.ts
@@ -112,7 +112,7 @@ export function transformCompareAndSetReply(
 }
 
 export function compareAndSet(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   key: string | Buffer,
   compareOperator: CompareOperator,

--- a/src/operations/compareAndSet.ts
+++ b/src/operations/compareAndSet.ts
@@ -33,6 +33,22 @@ declare module 'ioredis' {
     ): Promise<[Buffer, null | 1]>;
   }
 
+  interface Cluster {
+    lcCompareAndSetBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      key: string | Buffer,
+      compareOperator: string,
+      compareVersion: string,
+      value: Buffer,
+      version: string,
+      maxlen: number,
+    ): Promise<[Buffer, null | 1]>;
+  }
+
   interface Pipeline {
     lcCompareAndSetBuffer(
       valuesKey: string,
@@ -51,7 +67,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineCompareAndSetCommand(redis: IORedis.Redis) {
+export function defineCompareAndSetCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcCompareAndSet', definition);
 }
 

--- a/src/operations/get.ts
+++ b/src/operations/get.ts
@@ -24,6 +24,15 @@ declare module 'ioredis' {
     ): Promise<[Buffer, Buffer?, Buffer?]>;
   }
 
+  interface Cluster {
+    lcGetBuffer(
+      valuesKey: string,
+      versionsKey: string,
+      revisionKey: string,
+      key: string | Buffer,
+    ): Promise<[Buffer, Buffer?, Buffer?]>;
+  }
+
   interface Pipeline {
     lcGetBuffer(
       valuesKey: string,
@@ -35,7 +44,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineGetCommand(redis: IORedis.Redis) {
+export function defineGetCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcGet', definition);
 }
 

--- a/src/operations/getAll.ts
+++ b/src/operations/getAll.ts
@@ -1,4 +1,4 @@
-import {Redis} from 'ioredis';
+import IORedis = require('ioredis');
 import {
   VALUES_HASH_SUFFIX,
   VERSIONS_SORTED_SET_SUFFIX,
@@ -14,7 +14,7 @@ export type GetAllResult = {
 };
 
 export async function getAll(
-  redis: Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
 ): Promise<GetAllResult> {
   const [

--- a/src/operations/getKeyRange.ts
+++ b/src/operations/getKeyRange.ts
@@ -92,7 +92,7 @@ export function transformGetKeyRangeReply(
 }
 
 export function getKeyRange(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   min: string | Buffer,
   max: string | Buffer,

--- a/src/operations/getKeyRange.ts
+++ b/src/operations/getKeyRange.ts
@@ -28,6 +28,17 @@ declare module 'ioredis' {
     ): Promise<[Buffer, Array<[Buffer, Buffer, Buffer]>]>;
   }
 
+  interface Cluster {
+    lcGetKeyRangeBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      revisionKey: string,
+      min: string | Buffer,
+      max: string | Buffer,
+    ): Promise<[Buffer, Array<[Buffer, Buffer, Buffer]>]>;
+  }
+
   interface Pipeline {
     lcGetKeyRangeBuffer(
       valuesKey: string,
@@ -41,7 +52,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineGetKeyRangeCommand(redis: IORedis.Redis) {
+export function defineGetKeyRangeCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcGetKeyRange', definition);
 }
 

--- a/src/operations/getVersionRange.ts
+++ b/src/operations/getVersionRange.ts
@@ -87,7 +87,7 @@ export function transformGetVersionRangeReply(
 }
 
 export function getVersionRange(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   min: number | string,
   max: number | string,

--- a/src/operations/getVersionRange.ts
+++ b/src/operations/getVersionRange.ts
@@ -26,6 +26,16 @@ declare module 'ioredis' {
     ): Promise<[Buffer, Array<[Buffer, Buffer, Buffer]>]>;
   }
 
+  interface Cluster {
+    lcGetVersionRangeBuffer(
+      valuesKey: string,
+      versionsKey: string,
+      revisionKey: string,
+      min: string,
+      max: string,
+    ): Promise<[Buffer, Array<[Buffer, Buffer, Buffer]>]>;
+  }
+
   interface Pipeline {
     lcGetVersionRangeBuffer(
       valuesKey: string,
@@ -38,7 +48,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineGetVersionRangeCommand(redis: IORedis.Redis) {
+export function defineGetVersionRangeCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcGetVersionRange', definition);
 }
 

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -87,7 +87,7 @@ export function transformRemoveReply(reply: [Buffer]): RemoveResult {
 }
 
 export function remove(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   key: string | Buffer,
   maxlen: number = 1000,

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -28,6 +28,18 @@ declare module 'ioredis' {
     ): Promise<[Buffer]>;
   }
 
+  interface Cluster {
+    lcRemoveBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      key: string | Buffer,
+      maxlen: number,
+    ): Promise<[Buffer]>;
+  }
+
   interface Pipeline {
     lcRemoveBuffer(
       valuesKey: string,
@@ -42,7 +54,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineRemoveCommand(redis: IORedis.Redis) {
+export function defineRemoveCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcRemove', definition);
 }
 

--- a/src/operations/removeKeyRange.ts
+++ b/src/operations/removeKeyRange.ts
@@ -29,6 +29,19 @@ declare module 'ioredis' {
     ): Promise<[Buffer, number]>;
   }
 
+  interface Cluster {
+    lcRemoveKeyRangeBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      min: string | Buffer,
+      max: string | Buffer,
+      maxlen: number,
+    ): Promise<[Buffer, number]>;
+  }
+
   interface Pipeline {
     lcRemoveKeyRangeBuffer(
       valuesKey: string,
@@ -44,7 +57,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineRemoveKeyRangeCommand(redis: IORedis.Redis) {
+export function defineRemoveKeyRangeCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcRemoveKeyRange', definition);
 }
 

--- a/src/operations/removeKeyRange.ts
+++ b/src/operations/removeKeyRange.ts
@@ -96,7 +96,7 @@ export function transformRemoveKeyRangeReply(
 }
 
 export function removeKeyRange(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   min: string | Buffer,
   max: string | Buffer,

--- a/src/operations/removeVersionRange.ts
+++ b/src/operations/removeVersionRange.ts
@@ -30,6 +30,19 @@ declare module 'ioredis' {
     ): Promise<[Buffer, number]>;
   }
 
+  interface Cluster {
+    lcRemoveVersionRangeBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      min: string,
+      max: string,
+      maxlen: number,
+    ): Promise<[Buffer, number]>;
+  }
+
   interface Pipeline {
     lcRemoveVersionRangeBuffer(
       valuesKey: string,
@@ -45,7 +58,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineRemoveVersionRangeCommand(redis: IORedis.Redis) {
+export function defineRemoveVersionRangeCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcRemoveVersionRange', definition);
 }
 

--- a/src/operations/removeVersionRange.ts
+++ b/src/operations/removeVersionRange.ts
@@ -97,7 +97,7 @@ export function transformRemoveVersionRangeReply(
 }
 
 export function removeVersionRange(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   min: number | string,
   max: number | string,

--- a/src/operations/set.ts
+++ b/src/operations/set.ts
@@ -31,6 +31,20 @@ declare module 'ioredis' {
     ): Promise<[Buffer]>;
   }
 
+  interface Cluster {
+    lcSetBuffer(
+      valuesKey: string,
+      keysKey: string,
+      versionsKey: string,
+      changesKey: string,
+      revisionKey: string,
+      key: string | Buffer,
+      value: Buffer,
+      version: string,
+      maxlen: number,
+    ): Promise<[Buffer]>;
+  }
+
   interface Pipeline {
     lcSetBuffer(
       valuesKey: string,
@@ -47,7 +61,7 @@ declare module 'ioredis' {
   }
 }
 
-export function defineSetCommand(redis: IORedis.Redis) {
+export function defineSetCommand(redis: IORedis.Redis | IORedis.Cluster) {
   redis.defineCommand('lcSet', definition);
 }
 

--- a/src/operations/set.ts
+++ b/src/operations/set.ts
@@ -98,7 +98,7 @@ export function transformSetReply(reply: [Buffer]): SetResult {
 }
 
 export function set(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   key: string | Buffer,
   value: Buffer,

--- a/src/operations/watch.ts
+++ b/src/operations/watch.ts
@@ -4,7 +4,7 @@ import {ChangeEvent, changeEventFromEntry} from '../changeEvents';
 import {getKey, CHANGES_STREAM_SUFFIX} from '../keys';
 
 export function watch(
-  redis: IORedis.Redis,
+  redis: IORedis.Redis | IORedis.Cluster,
   collection: string,
   lastRevision: string,
   blockMs: number = 2500,


### PR DESCRIPTION
`Commander` тип, от которого наследуются и `Redis` и `Cluster` лежит снаружи неймспейса `IORedis`. Пришлось сменить `IORedis.Redis` на `IORedis.Redis | IORedis.Cluster`.

В тестах используется только `IORedis.Redis`. Похоже надо написать тестов для `IORedis.Cluster`.